### PR TITLE
Fix concurrency warnings and modernize range parsing

### DIFF
--- a/Sources/YoutubeDL/Downloader.swift
+++ b/Sources/YoutubeDL/Downloader.swift
@@ -205,9 +205,7 @@ extension Downloader: URLSessionDownloadDelegate {
         )
         
         let kind = downloadTask.kind
-        let url = downloadTask.taskDescription.map {
-            URL(fileURLWithPath: $0, relativeTo: directory)
-        } ?? directory.appendingPathComponent("complete.mp4")
+        let url = URL(fileURLWithPath: taskDescription, relativeTo: directory)
 
         do {
             func resume(selector: @escaping ([URLSessionDownloadTask]) -> URLSessionDownloadTask?) {
@@ -250,7 +248,7 @@ extension Downloader: URLSessionDownloadDelegate {
                 guard range.upperBound >= size else {
                     resume { tasks in
                         tasks.first {
-                            $0.taskDescription == downloadTask.taskDescription
+                            $0.taskDescription == taskDescription
                             && $0.hasPrefix(range.upperBound)
                         }
                         ?? tasks.first { $0.hasPrefix(0) }

--- a/Sources/YoutubeDL/HTTPRange.swift
+++ b/Sources/YoutubeDL/HTTPRange.swift
@@ -36,17 +36,27 @@ extension HTTPURLResponse {
         
         guard let string = contentRange else { return nil }
         let scanner = Scanner(string: string)
-        var prefix: NSString?
-        var start: Int64 = -1
-        var end: Int64 = -1
-        var size: Int64 = -1
-        guard scanner.scanUpToCharacters(from: .decimalDigits, into: &prefix),
-              scanner.scanInt64(&start),
-              scanner.scanString("-", into: nil),
-              scanner.scanInt64(&end),
-              scanner.scanString("/", into: nil),
-              scanner.scanInt64(&size) else { return nil }
-        return (prefix as String?, Range(start...end), size)
+        if #available(iOS 13.0, *) {
+            guard let prefix = scanner.scanUpToCharacters(from: .decimalDigits),
+                  let start = scanner.scanInt64(),
+                  scanner.scanString("-") != nil,
+                  let end = scanner.scanInt64(),
+                  scanner.scanString("/") != nil,
+                  let size = scanner.scanInt64() else { return nil }
+            return (prefix, Range(start...end), size)
+        } else {
+            var prefix: NSString?
+            var start: Int64 = -1
+            var end: Int64 = -1
+            var size: Int64 = -1
+            guard scanner.scanUpToCharacters(from: .decimalDigits, into: &prefix),
+                  scanner.scanInt64(&start),
+                  scanner.scanString("-", into: nil),
+                  scanner.scanInt64(&end),
+                  scanner.scanString("/", into: nil),
+                  scanner.scanInt64(&size) else { return nil }
+            return (prefix as String?, Range(start...end), size)
+        }
     }
 }
 

--- a/Sources/YoutubeDL/YoutubeDL.swift
+++ b/Sources/YoutubeDL/YoutubeDL.swift
@@ -649,7 +649,8 @@ open class YoutubeDL: NSObject {
         session.outputFileType = .mp4
         print(#function, "merging...")
         
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
             let progress = self.downloader.progress
             progress.kind = nil
             progress.localizedDescription = NSLocalizedString("Merging...", comment: "Progress description")
@@ -658,8 +659,9 @@ open class YoutubeDL: NSObject {
             progress.completedUnitCount = 0
             progress.estimatedTimeRemaining = nil
         }
-        
-        session.exportAsynchronously {
+
+        session.exportAsynchronously { [weak self] in
+            guard let self = self else { return }
             print(#function, "finished merge", session.status.rawValue)
             print(#function, "took", self.downloader.dateComponentsFormatter.string(from: ProcessInfo.processInfo.systemUptime - t0) ?? "?")
             if session.status == .completed {
@@ -682,15 +684,16 @@ open class YoutubeDL: NSObject {
             return
         }
         
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
             guard UIApplication.shared.applicationState == .active else {
                 guard let index = self.pendingDownloads.firstIndex(where: { $0.directory.path == directory.path }) else { fatalError() }
                 self.pendingDownloads[index].transcodePending = true
-                
+
                 notify(body: NSLocalizedString("AskTranscode", comment: "Notification body"), identifier: NotificationRequestIdentifier.transcode.rawValue)
                 return
             }
-            
+
             //            let alert = UIAlertController(title: nil, message: NSLocalizedString("DoNotSwitch", comment: "Alert message"), preferredStyle: .alert)
             //            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Action"), style: .default, handler: nil))
             //            self.topViewController?.present(alert, animated: true, completion: nil)
@@ -701,7 +704,8 @@ open class YoutubeDL: NSObject {
         
         removeItem(at: outURL)
         
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
             let progress = self.downloader.progress
             progress.kind = nil
             progress.localizedDescription = NSLocalizedString("Transcoding...", comment: "Progress description")
@@ -714,15 +718,17 @@ open class YoutubeDL: NSObject {
             transcoder = Transcoder()
         }
         
-        transcoder?.progressBlock = { progress in
+        transcoder?.progressBlock = { [weak self] progress in
+            guard let self = self else { return }
             print(#function, "progress:", progress)
             let elapsed = ProcessInfo.processInfo.systemUptime - t0
             let speed = progress / elapsed
             let ETA = (1 - progress) / speed
-            
+
             guard ETA.isFinite else { return }
-            
-            DispatchQueue.main.async {
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
                 let _progress = self.downloader.progress
                 _progress.completedUnitCount = Int64(progress * 100)
                 _progress.estimatedTimeRemaining = ETA
@@ -742,12 +748,16 @@ open class YoutubeDL: NSObject {
         }
         
         notify(body: NSLocalizedString("FinishedTranscoding", comment: "Notification body"))
-        
-        tryMerge(directory: url.deletingLastPathComponent(), title: url.title, timeRange: download.timeRange)
+
+        guard tryMerge(directory: url.deletingLastPathComponent(), title: url.title, timeRange: download.timeRange) else {
+            print(#function, "Failed to merge streams for", url)
+            return
+        }
     }
     
     internal func export(_ url: URL) {
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
             let progress = self.downloader.progress
             progress.localizedDescription = nil
             progress.localizedAdditionalDescription = nil
@@ -763,15 +773,17 @@ open class YoutubeDL: NSObject {
         PHPhotoLibrary.shared().performChanges({
             _ = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url)
             //                            changeRequest.contentEditingOutput = output
-        }) { (success, error) in
+        }) { [weak self] (success, error) in
+            guard let self = self else { return }
             print(#function, success, error ?? "")
-            
+
             if let continuation = self.finishedContinuation {
                 continuation.yield(url)
             } else {
                 notify(body: NSLocalizedString("Download complete!", comment: "Notification body"))
             }
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
                 let progress = self.downloader.progress
                 progress.fileCompletedCount = 1
                 do {


### PR DESCRIPTION
## Summary
- ensure background download handlers use concrete task descriptions instead of unused bindings
- update HTTP range parsing to the modern Scanner API while keeping pre-iOS 13 compatibility
- prevent non-Sendable captures in asynchronous closures and handle merge failures during transcoding

## Testing
- `swift test` *(fails in this environment: Foundation headers unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68de9a5d83ec833283f3c32aff57617a